### PR TITLE
I've added two new README.md files:

### DIFF
--- a/Hunt_Career_Cypress/README.md
+++ b/Hunt_Career_Cypress/README.md
@@ -1,0 +1,173 @@
+# Hunt Career Cypress Automation Framework
+
+## Overview
+
+This framework is designed for automating tests for the Hunt Career application using Cypress. It provides a robust structure for writing, managing, and executing end-to-end tests, ensuring the application's quality and reliability. The framework leverages the Page Object Model (POM) for maintainable and scalable test scripts, uses fixtures for test data management, and generates comprehensive HTML reports using Mochawesome.
+
+## Project Structure
+
+The project follows a standard Cypress directory structure with some additions to organize test assets effectively:
+
+*   **`cypress/e2e`**: This directory contains all the test script files (also known as spec files). Each `.cy.js` file typically represents a test suite for a specific feature or functionality of the application.
+    *   Example: `login.cy.js`, `register.cy.js`, `search.cy.js`
+
+*   **`cypress/fixtures`**: Fixtures are used to store static test data that can be loaded into tests. This helps in separating test data from test logic, making tests cleaner and easier to manage. Data is typically stored in JSON or JS files.
+    *   Example: `loginData.json`, `registerData.js`, `searchData.json`
+
+*   **`cypress/pageObjects`**: This directory implements the Page Object Model (POM) design pattern. Each `.js` file represents a page in the application and encapsulates the page's elements and the actions that can be performed on them. This promotes reusability and maintainability of test code.
+    *   Example: `BasePage.js`, `LoginPage.js`, `RegisterPage.js`, `SearchPage.js`
+
+*   **`cypress/reports`**: Test execution reports are generated in this directory. This framework uses `mochawesome` to create detailed HTML reports, which include test summaries, individual test results, and often screenshots for failed tests.
+    *   The main report file is typically `html/index.html` within this directory after a test run that generates reports.
+
+*   **`cypress/screenshots`**: Cypress automatically captures screenshots when a test fails during `cypress run`. Screenshots can also be captured manually within tests using `cy.screenshot()`. These are stored in this directory, usually organized by the spec file and test name.
+
+*   **`cypress/support`**: This directory is crucial for extending Cypress's capabilities.
+    *   `commands.js`: Used to define custom Cypress commands. These commands help in creating reusable functions for common actions or assertions, making test scripts more concise and readable.
+    *   `e2e.js`: This file is executed before any test files. It's used for global configurations, importing custom commands, or setting up global before/after hooks.
+
+*   **`cypress/utils`**: Contains utility functions that can be used across different parts of the test framework. These might include functions for generating random data, formatting values, or other helper tasks.
+    *   Example: `utils.js`
+
+*   **`cypress.config.js`**: This is the main configuration file for Cypress. It allows you to define global settings such as `baseUrl`, viewport dimensions, environment variables, and configure plugins.
+
+## Prerequisites
+
+Before you can run the tests in this framework, ensure you have the following installed on your system:
+
+*   **Node.js**: Cypress is a Node.js application. You can download Node.js from [nodejs.org](https://nodejs.org/).
+*   **npm** (Node Package Manager): npm is distributed with Node.js, so it will be installed automatically. Alternatively, you can use **yarn**.
+
+## Installation
+
+1.  **Clone the repository** (if you haven't already):
+    ```bash
+    git clone <repository-url>
+    cd Hunt_Career_Cypress
+    ```
+
+2.  **Install project dependencies**:
+    Navigate to the project's root directory (`Hunt_Career_Cypress`) in your terminal and run the following command:
+    ```bash
+    npm install
+    ```
+    This command will download and install all the necessary packages defined in the `package.json` file, including Cypress and any plugins.
+
+## Running Tests
+
+There are several ways to execute the Cypress tests:
+
+1.  **Open Cypress Test Runner (Interactive Mode)**:
+    This command opens the Cypress application, allowing you to see your spec files and run them individually or all at once. It's great for development and debugging.
+    ```bash
+    npx cypress open
+    ```
+
+2.  **Run Tests in Headless Mode**:
+    This command runs all tests in the Cypress Electron browser headlessly (without opening the UI). This is ideal for CI/CD environments or when you want a quick run of all tests.
+    ```bash
+    npx cypress run
+    ```
+    You can also specify a particular browser or spec file:
+    ```bash
+    npx cypress run --browser chrome
+    npx cypress run --spec "cypress/e2e/login.cy.js"
+    ```
+
+3.  **Using `package.json` Scripts** (if available):
+    Check the `scripts` section in the `package.json` file for any predefined aliases for running tests. For example, you might have scripts like:
+    ```json
+    "scripts": {
+      "cy:open": "cypress open",
+      "cy:run": "cypress run",
+      "report:merge": "mochawesome-merge cypress/reports/json/*.json > cypress/reports/report.json",
+      "report:generate": "marge cypress/reports/report.json -f report -o cypress/reports"
+    }
+    ```
+    If such scripts exist, you can run them using:
+    ```bash
+    npm run cy:open
+    npm run cy:run
+    ```
+    To generate reports after a headless run, you might use:
+    ```bash
+    npm run report:merge
+    npm run report:generate
+    ```
+
+## Reporting
+
+This framework uses the **Mochawesome** reporter to generate comprehensive HTML reports for test runs. Mochawesome provides a clear and detailed overview of test results, including pass/fail status, execution time, and individual test steps.
+
+*   **How it works**: When tests are run (especially in headless mode), Mochawesome generates JSON files for each spec. These JSON files can then be merged and converted into a single HTML report.
+*   **Viewing Reports**:
+    1.  After running tests (e.g., using `npx cypress run` or a custom script that includes report generation), the HTML report will be generated in the `cypress/reports/` directory.
+    2.  The main report file to open in your browser is typically located at: `cypress/reports/html/index.html` (or `cypress/reports/report.html` if using the `marge` command directly as shown in package.json scripts).
+
+## Configuration
+
+The primary configuration for Cypress is managed in the `cypress.config.js` file. Key configurations include:
+
+*   **`baseUrl`**: This is a global URL that Cypress will use as a prefix for `cy.visit()` and `cy.request()` commands. For example, if `baseUrl` is `https_huntcareer.com`, then `cy.visit('/login')` will navigate to `https_huntcareer.com/login`. This should be set to the base URL of the application under test.
+*   **Viewport Dimensions**: You can set default `viewportWidth` and `viewportHeight` for your tests.
+*   **Environment Variables (`env`)**: Custom environment variables can be defined here and accessed within your tests using `Cypress.env('variableName')`.
+*   **e2e options**:
+    *   `specPattern`: Defines the pattern Cypress uses to find test files (e.g., `cypress/e2e/**/*.cy.{js,jsx,ts,tsx}`).
+    *   `supportFile`: Points to the `e2e.js` file (`cypress/support/e2e.js`).
+*   **Reporter Configuration**: Settings for Mochawesome (or other reporters) can be configured here, such as `reporter`, `reporterOptions` (e.g., `overwrite`, `html`, `json`).
+
+Users might need to modify `baseUrl` or other environment-specific settings in `cypress.config.js` depending on the testing environment (e.g., development, staging, production).
+
+## Custom Commands
+
+Custom commands provide a way to abstract common sequences of actions or complex logic into reusable functions. They help in making test scripts more readable, maintainable, and DRY (Don't Repeat Yourself).
+
+*   **Definition**: Custom commands are defined in the `cypress/support/commands.js` file.
+    ```javascript
+    // Example of a custom login command in commands.js
+    Cypress.Commands.add('login', (email, password) => {
+      cy.visit('/login');
+      cy.get('input[name="email"]').type(email);
+      cy.get('input[name="password"]').type(password);
+      cy.get('button[type="submit"]').click();
+    });
+    ```
+*   **Usage**: Once defined, these commands can be used in any test script like standard Cypress commands:
+    ```javascript
+    // Example usage in a test file
+    it('should login successfully', () => {
+      cy.login('user@example.com', 'password123');
+      cy.url().should('include', '/dashboard');
+    });
+    ```
+    Ensure that `cypress/support/e2e.js` imports `commands.js` (which it does by default: `import './commands'`).
+
+## Page Object Model (POM)
+
+This framework utilizes the Page Object Model (POM) design pattern to create a scalable and maintainable test automation suite.
+
+*   **Concept**: In POM, each web page in the application is represented by a corresponding class (a "Page Object"). This class contains:
+    *   Locators for the web elements on that page.
+    *   Methods that represent the actions a user can perform on that page (e.g., `fillLoginForm()`, `submitLogin()`).
+*   **Implementation**: Page Objects are stored in the `cypress/pageObjects` directory.
+    *   Example: `LoginPage.js` might define methods like `enterUsername()`, `enterPassword()`, and `clickLoginButton()`.
+*   **Benefits**:
+    *   **Reusability**: Page-specific logic is encapsulated in one place and can be reused across multiple test scripts.
+    *   **Maintainability**: If the UI of a page changes, only the corresponding Page Object needs to be updated, not all the test scripts that use that page.
+    *   **Readability**: Test scripts become more readable as they call high-level methods from Page Objects, making the test intent clearer.
+
+    ```javascript
+    // Example of using a LoginPage object in a test
+    import LoginPage from '../pageObjects/LoginPage';
+
+    it('should login successfully using POM', () => {
+      const loginPage = new LoginPage();
+      loginPage.visit();
+      loginPage.fillEmail('user@example.com');
+      loginPage.fillPassword('password123');
+      loginPage.submit();
+      cy.url().should('include', '/dashboard');
+    });
+    ```
+
+This README provides a comprehensive guide to understanding, setting up, and running tests with the Hunt Career Cypress Automation Framework.

--- a/Hunt_Career_Playwright/README.md
+++ b/Hunt_Career_Playwright/README.md
@@ -1,0 +1,230 @@
+# Hunt Career Playwright Automation Framework
+
+## Overview
+
+This framework is built to automate end-to-end testing for the Hunt Career application using Playwright. It provides a robust and efficient structure for writing, managing, and executing tests, aiming to ensure the application's quality, reliability, and cross-browser compatibility. The framework leverages the Page Object Model (POM) for maintainable test scripts, uses external files for test data management, and utilizes Playwright's built-in reporting capabilities.
+
+## Project Structure
+
+The project follows a standard Playwright directory structure with specific conventions to organize test assets effectively:
+
+*   **`.github/workflows`**: This directory contains CI/CD pipeline configurations.
+    *   `playwright.yml`: Defines a GitHub Actions workflow for automatically running Playwright tests, often triggered on pushes or pull requests.
+
+*   **`data`**: Stores test data used by the test scripts. Separating data from test logic makes tests cleaner and easier to manage, especially when dealing with multiple data sets.
+    *   Example: `loginData.json`, `registerData.js`, `searchData.json`
+
+*   **`pages`**: Implements the Page Object Model (POM). Each `.js` file in this directory represents a page (or a significant component) of the application. It encapsulates the page's elements and the interaction methods associated with them.
+    *   Example: `BasePage.js`, `LoginPage.js`, `RegisterPage.js`, `SearchPage.js`
+
+*   **`tests`**: Contains all the test script files (spec files). Each `*.spec.js` file typically groups tests for a specific feature or user flow of the application.
+    *   Example: `login.spec.js`, `register.spec.js`, `search.spec.js`
+
+*   **`utils`**: This directory holds utility functions and custom command-like helpers that can be reused across different parts of the framework.
+    *   `utils.js`: General helper functions (e.g., generating random data, date formatting).
+    *   `commands.js`: While Playwright doesn't have a direct equivalent to Cypress's custom commands that extend its core API (`cy.`), this file can be used to centralize common sequences of actions or complex interactions that are reused in multiple tests, often by importing them into test files or page objects.
+
+*   **`playwright.config.js`**: The main configuration file for Playwright. It allows you to define global settings such as `baseURL`, browser projects (Chromium, Firefox, WebKit), viewport dimensions, test timeouts, and reporter options.
+
+*   **`playwright-report`**: This is the default directory where Playwright stores its HTML reports after test execution. It will also contain other artifacts like screenshots and videos if configured.
+
+## Prerequisites
+
+Before you can run the tests, ensure you have the following installed:
+
+*   **Node.js**: Playwright is a Node.js library. Download Node.js from [nodejs.org](https://nodejs.org/).
+*   **npm** (Node Package Manager): npm is distributed with Node.js. Alternatively, you can use **yarn**.
+
+## Installation
+
+1.  **Clone the repository** (if you haven't already):
+    ```bash
+    git clone <repository-url>
+    cd Hunt_Career_Playwright
+    ```
+
+2.  **Install project dependencies**:
+    Navigate to the project's root directory (`Hunt_Career_Playwright`) in your terminal and run:
+    ```bash
+    npm install
+    ```
+    This command installs all packages listed in `package.json`, including Playwright.
+
+3.  **Install Playwright browsers**:
+    Playwright requires browser binaries for Chromium, Firefox, and WebKit to run tests. Install them using:
+    ```bash
+    npx playwright install
+    ```
+    You can also install specific browsers, e.g., `npx playwright install chromium`.
+
+## Running Tests
+
+Playwright provides a powerful CLI to execute tests:
+
+1.  **Run All Tests**:
+    This command runs all tests found in the `tests` directory across all configured browsers (projects) in headless mode by default.
+    ```bash
+    npx playwright test
+    ```
+
+2.  **Run Tests in Specific Browsers (Projects)**:
+    You can target specific browser projects defined in `playwright.config.js`.
+    ```bash
+    npx playwright test --project=chromium
+    npx playwright test --project=firefox
+    npx playwright test --project=webkit
+    ```
+
+3.  **Run Tests in Headed Mode**:
+    To watch the tests execute in a browser UI, use the `--headed` flag.
+    ```bash
+    npx playwright test --headed
+    ```
+    You can combine this with a project flag:
+    ```bash
+    npx playwright test --project=chromium --headed
+    ```
+
+4.  **Run Specific Test Files or Tests**:
+    To run a specific file:
+    ```bash
+    npx playwright test tests/login.spec.js
+    ```
+    To run a test with a specific title (using grep):
+    ```bash
+    npx playwright test -g "user registration"
+    ```
+
+5.  **Using `package.json` Scripts**:
+    Check the `scripts` section in `package.json` for any predefined aliases. For example:
+    ```json
+    "scripts": {
+      "test": "npx playwright test",
+      "test:headed": "npx playwright test --headed",
+      "report": "npx playwright show-report"
+    }
+    ```
+    If such scripts exist, you can run them using:
+    ```bash
+    npm test
+    npm run test:headed
+    npm run report
+    ```
+
+## Reporting
+
+Playwright comes with a built-in HTML reporter that provides a detailed overview of test execution results.
+
+*   **Generation**: The HTML report is automatically generated after tests are run. By default, it's saved in the `playwright-report` directory.
+*   **Viewing Reports**:
+    After a test run, you can open the HTML report using the following command:
+    ```bash
+    npx playwright show-report playwright-report
+    ```
+    (If you've configured a custom report path in `playwright.config.js`, replace `playwright-report` with that path).
+    This command starts a local web server and opens the report in your default browser. The report includes:
+    *   Summary of test runs (pass/fail/skipped).
+    *   Details for each test, including steps.
+    *   Screenshots, videos, and traces if configured.
+
+## Configuration
+
+The `playwright.config.js` file is central to configuring Playwright for your project. Key settings include:
+
+*   **`baseURL`**: Defined within the `use` option. It's a global URL prefix for actions like `page.goto('/')`. For example, if `baseURL` is `https_huntcareer.com`, `page.goto('/login')` will navigate to `https_huntcareer.com/login`. This should be set to the base URL of the application under test.
+
+*   **Browser Configurations (`projects`)**: Playwright can run tests across different browser engines. Projects are defined in the `projects` array. Each project can specify the browser engine and other settings.
+    ```javascript
+    projects: [
+      { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+      { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+      { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+    ]
+    ```
+
+*   **Global Test Settings (`use`)**:
+    *   **`headless`**: Boolean to run browsers in headless mode (default `true`). Set to `false` to always run headed.
+    *   **`screenshot`**: Controls automatic screenshot capture. Options include `off`, `on`, or `only-on-failure` (default).
+    *   **`video`**: Controls video recording. Options: `off`, `on`, `retain-on-failure`, `on-first-retry`.
+    *   **`trace`**: Captures detailed trace information for debugging. Options: `off`, `on`, `retain-on-failure`, `on-first-retry`. Traces are invaluable for post-mortem debugging and can be viewed in the Playwright Trace Viewer.
+
+*   **Reporter Configuration**: You can configure multiple reporters. The HTML reporter is usually configured by default.
+    ```javascript
+    reporter: [['html', { open: 'never', outputFolder: 'playwright-report' }]],
+    ```
+
+## Utility Functions/Commands
+
+The `utils/` directory provides helper functions and shared logic:
+
+*   **`utils/utils.js`**: This file typically contains general utility functions that can be used anywhere in the framework. Examples include:
+    *   Generating random strings or numbers for test data.
+    *   Date/time manipulation.
+    *   Custom data formatters.
+
+*   **`utils/commands.js`**: While Playwright doesn't have a direct equivalent to Cypress's `cy.commands.add()`, this file can be used to structure reusable sequences of actions or complex interactions. These functions can then be imported and used within page objects or test files to keep test logic DRY.
+    ```javascript
+    // Example in utils/commands.js
+    export async function performLogin(page, username, password) {
+      await page.fill('#username', username);
+      await page.fill('#password', password);
+      await page.click('#loginButton');
+    }
+
+    // Usage in a test
+    import { performLogin } from '../utils/commands';
+    test('should login', async ({ page }) => {
+      await page.goto('/login');
+      await performLogin(page, 'user@example.com', 'pass123');
+      // ... assertions
+    });
+    ```
+
+## Page Object Model (POM)
+
+This framework employs the Page Object Model (POM) to enhance test maintenance and readability.
+
+*   **Concept**: Each page (or major component) of the application is represented by a class in the `pages/` directory. This class includes:
+    *   Selectors (locators) for the elements on the page.
+    *   Methods that perform actions or retrieve state from these elements.
+*   **Implementation**:
+    *   Page objects are stored in `pages/`. For example, `LoginPage.js` would manage interactions with the login page.
+    *   A `BasePage.js` might be used to define common functionality or elements shared across multiple pages (e.g., navigation headers, footers).
+*   **Benefits**:
+    *   **Encapsulation**: UI interactions are encapsulated within the page object, separating test logic from UI specifics.
+    *   **Reusability**: Page objects and their methods can be reused across many tests.
+    *   **Maintainability**: If the UI changes, updates are typically needed only in the relevant page object, not in every test script that interacts with that part of the UI.
+    *   **Readability**: Tests become cleaner by calling descriptive methods on page objects (e.g., `loginPage.loginWithCredentials(user, pass)`).
+
+    ```javascript
+    // Example: pages/LoginPage.js
+    export class LoginPage {
+      constructor(page) {
+        this.page = page;
+        this.usernameInput = page.locator('#username');
+        this.passwordInput = page.locator('#password');
+        this.submitButton = page.locator('button[type="submit"]');
+      }
+
+      async navigate() {
+        await this.page.goto('/login');
+      }
+
+      async login(username, password) {
+        await this.usernameInput.fill(username);
+        await this.passwordInput.fill(password);
+        await this.submitButton.click();
+      }
+    }
+
+    // Example usage in a test: tests/login.spec.js
+    import { LoginPage } from '../pages/LoginPage';
+    test('should login successfully', async ({ page }) => {
+      const loginPage = new LoginPage(page);
+      await loginPage.navigate();
+      await loginPage.login('user@example.com', 'securepassword');
+      // Add assertions here
+    });
+    ```
+
+This README provides a comprehensive guide for developers and testers to get started with the Hunt Career Playwright Automation Framework.


### PR DESCRIPTION
1. Hunt_Career_Cypress/README.md: This file provides a comprehensive guide for the Cypress automation framework. It includes details on setup, project structure, how to run tests, reporting with Mochawesome, configuration, custom commands, and using the Page Object Model.

2. Hunt_Career_Playwright/README.md: This file offers a detailed guide for the Playwright automation framework. It covers setup, project structure (including a GitHub Actions workflow), how to run tests, reporting with the Playwright HTML reporter, configuration, utility functions, and using the Page Object Model.

These READMEs are designed to help you understand, set up, and effectively use both testing frameworks.