### PR TITLE
Fix: Correct individual Jenkinsfiles to be runnable

### DIFF
--- a/Hunt_Career_Cypress/Jenkinsfile
+++ b/Hunt_Career_Cypress/Jenkinsfile
@@ -15,34 +15,28 @@ pipeline {
 
         stage('Install Dependencies') {
             steps {
-                dir('Hunt_Career_Cypress') {
-                    echo 'Installing npm dependencies...'
-                    bat 'npm install'
-                }
+                echo 'Installing npm dependencies...'
+                bat 'npm install'
             }
         }
 
         stage('Debug Workspace') {
             steps {
-                dir('Hunt_Career_Cypress') {
-                    echo 'Debugging workspace structure...'
-                    bat 'dir'
-                }
+                echo 'Debugging workspace structure...'
+                bat 'dir'
             }
         }
 
         stage('Debug Report Folder') {
             steps {
-                dir('Hunt_Career_Cypress') {
-                    script {
-                        echo 'Checking if mochawesome-report folder exists...'
-                        def reportExists = fileExists('mochawesome-report')
-                        if (reportExists) {
-                            echo 'mochawesome-report exists. Listing contents...'
-                            bat 'dir mochawesome-report'
-                        } else {
-                            echo 'mochawesome-report directory does NOT exist.'
-                        }
+                script {
+                    echo 'Checking if mochawesome-report folder exists...'
+                    def reportExists = fileExists('mochawesome-report')
+                    if (reportExists) {
+                        echo 'mochawesome-report exists. Listing contents...'
+                        bat 'dir mochawesome-report'
+                    } else {
+                        echo 'mochawesome-report directory does NOT exist.'
                     }
                 }
             }
@@ -50,26 +44,22 @@ pipeline {
 
         stage('Clean Previous Reports') {
             steps {
-                dir('Hunt_Career_Cypress') {
-                    echo 'Cleaning old report files if they exist...'
-                    bat 'if exist mochawesome-report rmdir /s /q mochawesome-report'
-                    bat 'if exist mochawesome.json del mochawesome.json'
-                }
+                echo 'Cleaning old report files if they exist...'
+                bat 'if exist mochawesome-report rmdir /s /q mochawesome-report'
+                bat 'if exist mochawesome.json del mochawesome.json'
             }
         }
 
         stage('Run Cypress Tests') {
             steps {
-                dir('Hunt_Career_Cypress') {
-                    script {
-                        try {
-                            echo 'Running Cypress tests and generating report...'
-                            bat 'npm run test:run:report'
-                        } catch (any) {
-                            currentBuild.result = 'UNSTABLE'
-                            echo "Cypress tests execution failed or reported errors. Build set to UNSTABLE."
-                            throw any // Re-throw the error
-                        }
+                script {
+                    try {
+                        echo 'Running Cypress tests and generating report...'
+                        bat 'npm run test:run:report'
+                    } catch (any) {
+                        currentBuild.result = 'UNSTABLE'
+                        echo "Cypress tests execution failed or reported errors. Build set to UNSTABLE."
+                        throw any // Re-throw the error
                     }
                 }
             }
@@ -80,16 +70,16 @@ pipeline {
         always {
             echo 'Pipeline finished. Archiving artifacts and publishing reports...'
             // Existing archiveArtifacts for reports, screenshots, videos
-            archiveArtifacts artifacts: 'Hunt_Career_Cypress/mochawesome-report/mochawesome*.html', allowEmptyArchive: true
-            archiveArtifacts artifacts: 'Hunt_Career_Cypress/cypress/screenshots/**/*.png', allowEmptyArchive: true
-            archiveArtifacts artifacts: 'Hunt_Career_Cypress/cypress/videos/**/*.mp4', allowEmptyArchive: true
+            archiveArtifacts artifacts: 'mochawesome-report/mochawesome*.html', allowEmptyArchive: true
+            archiveArtifacts artifacts: 'cypress/screenshots/**/*.png', allowEmptyArchive: true
+            archiveArtifacts artifacts: 'cypress/videos/**/*.mp4', allowEmptyArchive: true
 
             // Add HTML Publisher step
             publishHTML(target: [
                 allowMissing: true,
                 alwaysLinkToLastBuild: true,
                 keepAll: true,
-                reportDir: 'Hunt_Career_Cypress/mochawesome-report', // Path from workspace root
+                reportDir: 'mochawesome-report', // Path from workspace root
                 reportFiles: 'mochawesome.html', // Main html file, adjust if different
                 reportName: 'Cypress Test Report'
             ])

--- a/Hunt_Career_Playwright/Jenkinsfile
+++ b/Hunt_Career_Playwright/Jenkinsfile
@@ -15,34 +15,28 @@ pipeline {
 
         stage('Install Dependencies') {
             steps {
-                dir('Hunt_Career_Playwright') {
-                    echo 'Installing npm dependencies...'
-                    bat 'npm install'
-                }
+                echo 'Installing npm dependencies...'
+                bat 'npm install'
             }
         }
 
         stage('Install Playwright Browsers') {
             steps {
-                dir('Hunt_Career_Playwright') {
-                    echo 'Installing Playwright browsers...'
-                    bat 'npx playwright install --with-deps'
-                }
+                echo 'Installing Playwright browsers...'
+                bat 'npx playwright install --with-deps'
             }
         }
 
         stage('Run Playwright Tests') {
             steps {
-                dir('Hunt_Career_Playwright') {
-                    script {
-                        try {
-                            echo 'Running Playwright tests...'
-                            bat 'npx playwright test'
-                        } catch (any) {
-                            currentBuild.result = 'UNSTABLE'
-                            echo "Playwright tests execution failed or reported errors. Build set to UNSTABLE."
-                            throw any // Re-throw the error
-                        }
+                script {
+                    try {
+                        echo 'Running Playwright tests...'
+                        bat 'npx playwright test'
+                    } catch (any) {
+                        currentBuild.result = 'UNSTABLE'
+                        echo "Playwright tests execution failed or reported errors. Build set to UNSTABLE."
+                        throw any // Re-throw the error
                     }
                 }
             }
@@ -53,16 +47,14 @@ pipeline {
         always {
             echo 'Pipeline finished. Archiving and publishing reports...'
             // Existing archiveArtifacts for Playwright reports
-            dir('Hunt_Career_Playwright') { // Ensure dir context for archive if paths are relative
-                archiveArtifacts artifacts: 'playwright-report/**/*', allowEmptyArchive: true
-            }
+            archiveArtifacts artifacts: 'playwright-report/**/*', allowEmptyArchive: true
 
             // Add HTML Publisher step for Playwright report
             publishHTML(target: [
                 allowMissing: true,
                 alwaysLinkToLastBuild: true,
                 keepAll: true,
-                reportDir: 'Hunt_Career_Playwright/playwright-report', // Path from workspace root
+                reportDir: 'playwright-report', // Path from workspace root
                 reportFiles: 'index.html', // Main html file
                 reportName: 'Playwright Test Report'
             ])

--- a/Hunt_Career_TestNG_Hybrid_Framework/Jenkinsfile
+++ b/Hunt_Career_TestNG_Hybrid_Framework/Jenkinsfile
@@ -16,25 +16,21 @@ pipeline {
 
         stage('Build') {
             steps {
-                dir('Hunt_Career_TestNG_Hybrid_Framework') {
-                    echo 'Building the project...'
-                    bat 'mvn -B clean install -DskipTests'
-                }
+                echo 'Building the project...'
+                bat 'mvn -B clean install -DskipTests'
             }
         }
 
         stage('Test') {
             steps {
-                dir('Hunt_Career_TestNG_Hybrid_Framework') {
-                    script {
-                        try {
-                            echo 'Running tests...'
-                            bat 'mvn -B test'
-                        } catch (any) {
-                            currentBuild.result = 'UNSTABLE'
-                            echo "TestNG tests execution failed or reported errors. Build set to UNSTABLE."
-                            throw any // Re-throw the error
-                        }
+                script {
+                    try {
+                        echo 'Running tests...'
+                        bat 'mvn -B test'
+                    } catch (any) {
+                        currentBuild.result = 'UNSTABLE'
+                        echo "TestNG tests execution failed or reported errors. Build set to UNSTABLE."
+                        throw any // Re-throw the error
                     }
                 }
             }
@@ -42,12 +38,10 @@ pipeline {
 
         stage('Archive Reports') {
             steps {
-                dir('Hunt_Career_TestNG_Hybrid_Framework') {
-                    echo 'Archiving reports...'
-                    archiveArtifacts artifacts: 'test-output/ExtentReports/extentReport.html', allowEmptyArchive: true
-                    archiveArtifacts artifacts: 'test-output/emailable-report.html', allowEmptyArchive: true
-                    archiveArtifacts artifacts: 'test-output/testng-results.xml', allowEmptyArchive: true
-                }
+                echo 'Archiving reports...'
+                archiveArtifacts artifacts: 'test-output/ExtentReports/extentReport.html', allowEmptyArchive: true
+                archiveArtifacts artifacts: 'test-output/emailable-report.html', allowEmptyArchive: true
+                archiveArtifacts artifacts: 'test-output/testng-results.xml', allowEmptyArchive: true
             }
         }
     }
@@ -55,21 +49,18 @@ pipeline {
     post {
         always {
             echo 'Pipeline finished. Publishing reports and archiving...'
-            // Archiving is already relative to Hunt_Career_TestNG_Hybrid_Framework due to Jenkinsfile location, 
-            // but explicit dir is safer if Jenkinsfile moves.
-            // For publishTestNGResults, it's often workspace relative.
             
-            archiveArtifacts artifacts: 'Hunt_Career_TestNG_Hybrid_Framework/test-output/ExtentReports/extentReport.html', allowEmptyArchive: true
-            archiveArtifacts artifacts: 'Hunt_Career_TestNG_Hybrid_Framework/test-output/emailable-report.html', allowEmptyArchive: true
-            archiveArtifacts artifacts: 'Hunt_Career_TestNG_Hybrid_Framework/test-output/testng-results.xml', allowEmptyArchive: true
+            archiveArtifacts artifacts: 'test-output/ExtentReports/extentReport.html', allowEmptyArchive: true
+            archiveArtifacts artifacts: 'test-output/emailable-report.html', allowEmptyArchive: true
+            archiveArtifacts artifacts: 'test-output/testng-results.xml', allowEmptyArchive: true
             
-            junit testResults: 'Hunt_Career_TestNG_Hybrid_Framework/test-output/testng-results.xml', allowEmptyResults: true
+            junit testResults: 'test-output/testng-results.xml', allowEmptyResults: true
 
             publishHTML(target: [
                 allowMissing: true,
                 alwaysLinkToLastBuild: true,
                 keepAll: true,
-                reportDir: 'Hunt_Career_TestNG_Hybrid_Framework/test-output/ExtentReports', 
+                reportDir: 'test-output/ExtentReports',
                 reportFiles: 'extentReport.html', 
                 reportName: 'Extent Test Report'
             ])
@@ -78,7 +69,7 @@ pipeline {
                 allowMissing: true,
                 alwaysLinkToLastBuild: true,
                 keepAll: true,
-                reportDir: 'Hunt_Career_TestNG_Hybrid_Framework/test-output', 
+                reportDir: 'test-output',
                 reportFiles: 'emailable-report.html', 
                 reportName: 'TestNG Emailable Report'
             ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,133 @@
+pipeline {
+    agent any
+
+    tools {
+        nodejs 'NodeJS'
+        maven 'MAVEN'
+        jdk 'JAVA'
+    }
+
+    stages {
+        stage('Checkout') {
+            steps {
+                echo 'Checking out code...'
+                checkout scm
+            }
+        }
+
+        stage('Run Cypress Tests') {
+            steps {
+                dir('Hunt_Career_Cypress') {
+                    script {
+                        try {
+                            echo 'Installing npm dependencies for Cypress...'
+                            bat 'npm install'
+                            echo 'Running Cypress tests and generating report...'
+                            bat 'npm run test:run:report'
+                        } catch (any) {
+                            currentBuild.result = 'UNSTABLE'
+                            echo "Cypress tests execution failed or reported errors. Build set to UNSTABLE."
+                        }
+                    }
+                }
+            }
+        }
+
+        stage('Run Playwright Tests') {
+            steps {
+                dir('Hunt_Career_Playwright') {
+                    script {
+                        try {
+                            echo 'Installing npm dependencies for Playwright...'
+                            bat 'npm install'
+                            echo 'Installing Playwright browsers...'
+                            bat 'npx playwright install --with-deps'
+                            echo 'Running Playwright tests...'
+                            bat 'npx playwright test'
+                        } catch (any) {
+                            currentBuild.result = 'UNSTABLE'
+                            echo "Playwright tests execution failed or reported errors. Build set to UNSTABLE."
+                        }
+                    }
+                }
+            }
+        }
+
+        stage('Run TestNG Tests') {
+            steps {
+                dir('Hunt_Career_TestNG_Hybrid_Framework') {
+                    script {
+                        try {
+                            echo 'Building the TestNG project...'
+                            bat 'mvn -B clean install -DskipTests'
+                            echo 'Running TestNG tests...'
+                            bat 'mvn -B test'
+                        } catch (any) {
+                            currentBuild.result = 'UNSTABLE'
+                            echo "TestNG tests execution failed or reported errors. Build set to UNSTABLE."
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            echo 'Pipeline finished. Archiving artifacts and publishing reports...'
+
+            // Cypress reports
+            publishHTML(target: [
+                allowMissing: true,
+                alwaysLinkToLastBuild: true,
+                keepAll: true,
+                reportDir: 'Hunt_Career_Cypress/mochawesome-report',
+                reportFiles: 'mochawesome.html',
+                reportName: 'Cypress Test Report'
+            ])
+            archiveArtifacts artifacts: 'Hunt_Career_Cypress/mochawesome-report/mochawesome*.html', allowEmptyArchive: true
+            archiveArtifacts artifacts: 'Hunt_Career_Cypress/cypress/screenshots/**/*.png', allowEmptyArchive: true
+            archiveArtifacts artifacts: 'Hunt_Career_Cypress/cypress/videos/**/*.mp4', allowEmptyArchive: true
+
+            // Playwright reports
+            publishHTML(target: [
+                allowMissing: true,
+                alwaysLinkToLastBuild: true,
+                keepAll: true,
+                reportDir: 'Hunt_Career_Playwright/playwright-report',
+                reportFiles: 'index.html',
+                reportName: 'Playwright Test Report'
+            ])
+            archiveArtifacts artifacts: 'Hunt_Career_Playwright/playwright-report/**/*', allowEmptyArchive: true
+
+            // TestNG reports
+            junit testResults: 'Hunt_Career_TestNG_Hybrid_Framework/test-output/testng-results.xml', allowEmptyResults: true
+            publishHTML(target: [
+                allowMissing: true,
+                alwaysLinkToLastBuild: true,
+                keepAll: true,
+                reportDir: 'Hunt_Career_TestNG_Hybrid_Framework/test-output/ExtentReports',
+                reportFiles: 'extentReport.html',
+                reportName: 'Extent Test Report'
+            ])
+            publishHTML(target: [
+                allowMissing: true,
+                alwaysLinkToLastBuild: true,
+                keepAll: true,
+                reportDir: 'Hunt_Career_TestNG_Hybrid_Framework/test-output',
+                reportFiles: 'emailable-report.html',
+                reportName: 'TestNG Emailable Report'
+            ])
+            archiveArtifacts artifacts: 'Hunt_Career_TestNG_Hybrid_Framework/test-output/**/*', allowEmptyArchive: true
+        }
+        success {
+            echo 'All frameworks executed successfully!'
+        }
+        failure {
+            echo 'Pipeline failed.'
+        }
+        unstable {
+            echo 'One or more frameworks reported test failures.'
+        }
+    }
+}


### PR DESCRIPTION
This commit corrects the `Jenkinsfile`s in the `Hunt_Career_Cypress`, `Hunt_Career_Playwright`, and `Hunt_Career_TestNG_Hybrid_Framework` directories.

The `dir(...)` wrappers and the directory prefixes in the artifact paths have been removed. This allows each `Jenkinsfile` to be run individually from within its own project directory, which is useful for you if you want to run a single test suite without triggering the entire master pipeline.