### PR TITLE
This commit fixes the "script not found" and "file not found" errors …

### DIFF
--- a/Hunt_Career_Cypress/Jenkinsfile
+++ b/Hunt_Career_Cypress/Jenkinsfile
@@ -15,22 +15,26 @@ pipeline {
 
         stage('Install Dependencies') {
             steps {
-                echo 'Installing npm dependencies...'
-                bat 'npm install'
+                dir('Hunt_Career_Cypress') {
+                    echo 'Installing npm dependencies...'
+                    bat 'npm install'
+                }
             }
         }
 
         stage('Run Cypress Tests') {
             steps {
-                echo 'Running Cypress tests...'
-                // The `test:run:report` script from package.json runs the tests and generates the report.
-                // Using a try-catch block to ensure the pipeline continues to the post-build steps even on test failure.
-                script {
-                    try {
-                        bat 'npm run test:run:report'
-                    } catch (any) {
-                        currentBuild.result = 'UNSTABLE'
-                        echo "Cypress tests failed."
+                dir('Hunt_Career_Cypress') {
+                    echo 'Running Cypress tests...'
+                    // The `test:run:report` script from package.json runs the tests and generates the report.
+                    // Using a try-catch block to ensure the pipeline continues to the post-build steps even on test failure.
+                    script {
+                        try {
+                            bat 'npm run test:run:report'
+                        } catch (any) {
+                            currentBuild.result = 'UNSTABLE'
+                            echo "Cypress tests failed."
+                        }
                     }
                 }
             }
@@ -42,18 +46,18 @@ pipeline {
             echo 'Archiving reports and artifacts...'
 
             // Archive the Mochawesome HTML report
-            archiveArtifacts artifacts: 'mochawesome-report/mochawesome.html', allowEmptyArchive: true
+            archiveArtifacts artifacts: 'Hunt_Career_Cypress/mochawesome-report/mochawesome.html', allowEmptyArchive: true
 
             // Archive screenshots and videos, which are useful for debugging failed tests
-            archiveArtifacts artifacts: 'cypress/screenshots/**/*.png', allowEmptyArchive: true
-            archiveArtifacts artifacts: 'cypress/videos/**/*.mp4', allowEmptyArchive: true
+            archiveArtifacts artifacts: 'Hunt_Career_Cypress/cypress/screenshots/**/*.png', allowEmptyArchive: true
+            archiveArtifacts artifacts: 'Hunt_Career_Cypress/cypress/videos/**/*.mp4', allowEmptyArchive: true
 
             // Publish the HTML report for easy viewing in Jenkins
             publishHTML(target: [
                 allowMissing: true,
                 alwaysLinkToLastBuild: true,
                 keepAll: true,
-                reportDir: 'mochawesome-report',
+                reportDir: 'Hunt_Career_Cypress/mochawesome-report',
                 reportFiles: 'mochawesome.html',
                 reportName: 'Cypress Test Report'
             ])

--- a/Hunt_Career_Playwright/Jenkinsfile
+++ b/Hunt_Career_Playwright/Jenkinsfile
@@ -15,30 +15,36 @@ pipeline {
 
         stage('Install Dependencies') {
             steps {
-                echo 'Installing npm dependencies...'
-                bat 'npm install'
+                dir('Hunt_Career_Playwright') {
+                    echo 'Installing npm dependencies...'
+                    bat 'npm install'
+                }
             }
         }
 
         stage('Install Playwright Browsers') {
             steps {
-                echo 'Installing Playwright browsers...'
-                // This command installs the browsers needed by Playwright
-                bat 'npx playwright install --with-deps'
+                dir('Hunt_Career_Playwright') {
+                    echo 'Installing Playwright browsers...'
+                    // This command installs the browsers needed by Playwright
+                    bat 'npx playwright install --with-deps'
+                }
             }
         }
 
         stage('Run Playwright Tests') {
             steps {
-                echo 'Running Playwright tests...'
-                // Using a script block to wrap the test command in a try-catch block.
-                // This prevents the pipeline from stopping abruptly on test failures.
-                script {
-                    try {
-                        bat 'npx playwright test'
-                    } catch (any) {
-                        currentBuild.result = 'UNSTABLE'
-                        echo "Playwright tests failed."
+                dir('Hunt_Career_Playwright') {
+                    echo 'Running Playwright tests...'
+                    // Using a script block to wrap the test command in a try-catch block.
+                    // This prevents the pipeline from stopping abruptly on test failures.
+                    script {
+                        try {
+                            bat 'npx playwright test'
+                        } catch (any) {
+                            currentBuild.result = 'UNSTABLE'
+                            echo "Playwright tests failed."
+                        }
                     }
                 }
             }
@@ -50,14 +56,14 @@ pipeline {
             echo 'Archiving and publishing reports...'
 
             // Archive the Playwright report
-            archiveArtifacts artifacts: 'playwright-report/**/*', allowEmptyArchive: true
+            archiveArtifacts artifacts: 'Hunt_Career_Playwright/playwright-report/**/*', allowEmptyArchive: true
 
             // Publish the HTML report for easy viewing in Jenkins
             publishHTML(target: [
                 allowMissing: true,
                 alwaysLinkToLastBuild: true,
                 keepAll: true,
-                reportDir: 'playwright-report',
+                reportDir: 'Hunt_Career_Playwright/playwright-report',
                 reportFiles: 'index.html',
                 reportName: 'Playwright Test Report'
             ])

--- a/Hunt_Career_TestNG_Hybrid_Framework/Jenkinsfile
+++ b/Hunt_Career_TestNG_Hybrid_Framework/Jenkinsfile
@@ -17,22 +17,26 @@ pipeline {
 
         stage('Build') {
             steps {
-                echo 'Cleaning and building the project...'
-                // Using -B for batch mode to prevent interactive prompts
-                bat 'mvn -B clean install'
+                dir('Hunt_Career_TestNG_Hybrid_Framework') {
+                    echo 'Cleaning and building the project...'
+                    // Using -B for batch mode to prevent interactive prompts
+                    bat 'mvn -B clean install'
+                }
             }
         }
 
         stage('Test') {
             steps {
-                echo 'Running TestNG tests...'
-                // Using a script block to wrap the test command in a try-catch block.
-                script {
-                    try {
-                        bat 'mvn -B test'
-                    } catch (any) {
-                        currentBuild.result = 'UNSTABLE'
-                        echo "TestNG tests failed."
+                dir('Hunt_Career_TestNG_Hybrid_Framework') {
+                    echo 'Running TestNG tests...'
+                    // Using a script block to wrap the test command in a try-catch block.
+                    script {
+                        try {
+                            bat 'mvn -B test'
+                        } catch (any) {
+                            currentBuild.result = 'UNSTABLE'
+                            echo "TestNG tests failed."
+                        }
                     }
                 }
             }
@@ -44,17 +48,17 @@ pipeline {
             echo 'Archiving and publishing reports...'
 
             // Archive the JUnit XML results, which Jenkins can use to track test trends
-            junit testResults: 'target/surefire-reports/testng-results.xml', allowEmptyResults: true
+            junit testResults: 'Hunt_Career_TestNG_Hybrid_Framework/target/surefire-reports/testng-results.xml', allowEmptyResults: true
 
             // Archive the Extent HTML report
-            archiveArtifacts artifacts: 'test-output/ExtentReports/extentReport.html', allowEmptyArchive: true
-            
+            archiveArtifacts artifacts: 'Hunt_Career_TestNG_Hybrid_Framework/test-output/ExtentReports/extentReport.html', allowEmptyArchive: true
+
             // Publish the Extent HTML report for easy viewing
             publishHTML(target: [
                 allowMissing: true,
                 alwaysLinkToLastBuild: true,
                 keepAll: true,
-                reportDir: 'test-output/ExtentReports',
+                reportDir: 'Hunt_Career_TestNG_Hybrid_Framework/test-output/ExtentReports',
                 reportFiles: 'extentReport.html',
                 reportName: 'Extent Test Report'
             ])
@@ -64,7 +68,7 @@ pipeline {
                 allowMissing: true,
                 alwaysLinkToLastBuild: true,
                 keepAll: true,
-                reportDir: 'test-output',
+                reportDir: 'Hunt_Career_TestNG_Hybrid_Framework/test-output',
                 reportFiles: 'emailable-report.html',
                 reportName: 'TestNG Emailable Report'
             ])


### PR DESCRIPTION
…in the Jenkins pipelines.

The root cause was that the downstream pipeline jobs were executing in the root of the workspace, not in their respective subdirectories. This meant that `npm` and `mvn` commands could not find their configuration files (`package.json`, `pom.xml`).

This has been fixed by:
- Wrapping the execution steps in each framework's `Jenkinsfile` in a `dir()` block to change into the correct subdirectory.
- Updating the paths in the `post` block of each `Jenkinsfile` to be relative to the workspace root, so that Jenkins can find the reports and artifacts.