### PR TITLE
This commit fixes an error on Windows agents where the npm scripts we…

### DIFF
--- a/Hunt_Career_Cypress/package.json
+++ b/Hunt_Career_Cypress/package.json
@@ -14,9 +14,8 @@
     "@faker-js/faker": "^9.7.0"
   },
   "scripts": {
-    "cypress:open": "./node_modules/.bin/cypress open",
-    "cypress:run": "./node_modules/.bin/cypress run",
-    "move:json": "move mochawesome-report\\.jsons\\*.json mochawesome-report\\",
+    "cypress:open": "cypress open",
+    "cypress:run": "cypress run",
     "report:merge": "mochawesome-merge mochawesome-report/*.json -o mochawesome-report/mochawesome.json",
     "report:generate": "marge mochawesome-report/mochawesome.json -f report -o mochawesome-report",
     "report:full": "npm run report:merge && npm run report:generate",


### PR DESCRIPTION
…re failing with `'.' is not recognized as an internal or external command`.

The `cypress:run` and `cypress:open` scripts in `Hunt_Career_Cypress/package.json` were using the `./` syntax, which is not compatible with the Windows command prompt.

This has been fixed by changing the scripts to be platform-independent (e.g., `"cypress run"` instead of `"./node_modules/.bin/cypress run"`). `npm` automatically resolves the path to the executable in `node_modules/.bin`.