### PR TITLE
refactor: Use a constant for the job index in STC-6 test

### DIFF
--- a/Hunt_Career_Playwright/tests/search.spec.js
+++ b/Hunt_Career_Playwright/tests/search.spec.js
@@ -97,8 +97,9 @@ test.describe("Search Tests", () => {
   }) => {
     await loginAsValidUser(loginPage, loginData, page);
     await searchPage.search(searchData.validSearch.searchTerm);
-    const jobTitle = await searchPage.jobCardTitle(1).textContent();
-    await homePage.saveButton.nth(1).click();
+    const jobIndex = 1;
+    const jobTitle = await searchPage.jobCardTitle(jobIndex).textContent();
+    await homePage.saveButton.nth(jobIndex).click();
     await homePage.saveConfirmationPopup.click();
     await expect(homePage.savedMessage(jobTitle)).toBeVisible();
     await homePage.openUserMenu.click();


### PR DESCRIPTION
This commit refactors the STC-6 test case to use a constant for the job index, improving code clarity and maintainability as suggested by you.