### PR TITLE
refactor: Remove jobIndex variable and pass index directly

### DIFF
--- a/Hunt_Career_Playwright/pages/HomePage.js
+++ b/Hunt_Career_Playwright/pages/HomePage.js
@@ -4,7 +4,6 @@ export class HomePage extends BasePage {
   constructor(page) {
     super(page);
     this.viewDetailsLink = page.locator('//span[contains(text(), "View Details ")]');
-    this.saveButton = page.locator('//button[contains(text(), "Save")]');
     this.saveConfirmationPopup = page.locator('//button[contains(text(), "Confirm")]');
     this.openUserMenu = page.locator('//button[@aria-label = "Open user menu"]');
     this.clickOnSavedJobs = page.locator('//a[contains(text(), "Saved Jobs")]');

--- a/Hunt_Career_Playwright/pages/SearchPage.js
+++ b/Hunt_Career_Playwright/pages/SearchPage.js
@@ -26,6 +26,20 @@ export class SearchPage extends BasePage {
       "//button[@aria-label='Clear all filters']",
     );
     this.noJobsFoundMessage = page.locator('p:has-text("No jobs found.")');
+    this.jobCards = this.page.locator(
+      "div:has(h3[class*='text-lg'][class*='font-semibold'])",
+    );
+  }
+
+  getJobCardByIndex(index) {
+    const cardLocator = this.jobCards.nth(index);
+    const titleLocator = cardLocator.locator("h3");
+    const saveButtonLocator = cardLocator.locator("button:has-text('Save')");
+
+    return {
+      getTitle: async () => await titleLocator.textContent(),
+      clickSave: async () => await saveButtonLocator.click(),
+    };
   }
 
   // Dynamic locators
@@ -47,14 +61,6 @@ export class SearchPage extends BasePage {
 
   jobTypeOption(jobType) {
     return this.page.locator(`//label[contains(., "${jobType}")]//input`);
-  }
-
-  jobCardTitle(index) {
-    return this.page
-      .locator(
-        "//h3[contains(@class, 'text-lg') and contains(@class, 'font-semibold')]",
-      )
-      .nth(index);
   }
 
   jobCardCompanyLocation(jobCard) {

--- a/Hunt_Career_Playwright/tests/search.spec.js
+++ b/Hunt_Career_Playwright/tests/search.spec.js
@@ -97,9 +97,9 @@ test.describe("Search Tests", () => {
   }) => {
     await loginAsValidUser(loginPage, loginData, page);
     await searchPage.search(searchData.validSearch.searchTerm);
-    const jobIndex = 1;
-    const jobTitle = await searchPage.jobCardTitle(jobIndex).textContent();
-    await homePage.saveButton.nth(jobIndex).click();
+    const jobCard = searchPage.getJobCardByIndex(1);
+    const jobTitle = await jobCard.getTitle();
+    await jobCard.clickSave();
     await homePage.saveConfirmationPopup.click();
     await expect(homePage.savedMessage(jobTitle)).toBeVisible();
     await homePage.openUserMenu.click();


### PR DESCRIPTION
I removed the `jobIndex` variable from the STC-6 test case, passing the index directly to the `getJobCardByIndex` function. This makes the code more concise, as per your preference.