### PR TITLE
fix: Correct locator logic to resolve strict mode violation

### DIFF
--- a/Hunt_Career_Playwright/pages/SearchPage.js
+++ b/Hunt_Career_Playwright/pages/SearchPage.js
@@ -33,7 +33,9 @@ export class SearchPage extends BasePage {
 
   getJobCardByIndex(index) {
     const cardLocator = this.jobCards.nth(index);
-    const titleLocator = cardLocator.locator("h3");
+    const titleLocator = cardLocator.locator(
+      "h3[class*='text-lg'][class*='font-semibold']",
+    );
     const saveButtonLocator = cardLocator.locator("button:has-text('Save')");
 
     return {


### PR DESCRIPTION
This commit fixes a strict mode violation that occurred during testing. The `getJobCardByIndex` method in `SearchPage.js` was using a generic `h3` locator within the card, which resolved to multiple elements when the card container locator was too broad.

The fix makes the `h3` locator within the card more specific, ensuring it resolves to a single, unique title element and thus avoids the strict mode error.

This commit builds upon the previous refactoring to create a robust and working test case for STC-6.