### PR TITLE
fix: Implement robust locator strategy for job cards

### DIFF
--- a/Hunt_Career_Playwright/pages/SearchPage.js
+++ b/Hunt_Career_Playwright/pages/SearchPage.js
@@ -26,16 +26,16 @@ export class SearchPage extends BasePage {
       "//button[@aria-label='Clear all filters']",
     );
     this.noJobsFoundMessage = page.locator('p:has-text("No jobs found.")');
-    this.jobCards = this.page.locator(
-      "div:has(h3[class*='text-lg'][class*='font-semibold'])",
-    );
   }
 
   getJobCardByIndex(index) {
-    const cardLocator = this.jobCards.nth(index);
-    const titleLocator = cardLocator.locator(
-      "h3[class*='text-lg'][class*='font-semibold']",
-    );
+    const titleLocator = this.page
+      .locator(
+        "//h3[contains(@class, 'text-lg') and contains(@class, 'font-semibold')]",
+      )
+      .nth(index);
+
+    const cardLocator = titleLocator.locator("xpath=./ancestor::div[1]");
     const saveButtonLocator = cardLocator.locator("button:has-text('Save')");
 
     return {


### PR DESCRIPTION
This commit resolves a persistent "strict mode violation" error by implementing a new, more robust locator strategy for job cards in `SearchPage.js`.

The `getJobCardByIndex` method now works "inside-out":
1. It finds the specific `h3` title element by its index.
2. It then finds the parent `div` container for that title.
3. It finds the "Save" button within that specific container.

This approach is much more precise than the previous "outside-in" strategy and prevents the locator from incorrectly matching multiple elements. This change finally creates a stable and working test for the STC-6 use case.