### PR TITLE
fix: Revert to simpler logic for STC-6 test case

### DIFF
--- a/Hunt_Career_Playwright/pages/HomePage.js
+++ b/Hunt_Career_Playwright/pages/HomePage.js
@@ -4,6 +4,7 @@ export class HomePage extends BasePage {
   constructor(page) {
     super(page);
     this.viewDetailsLink = page.locator('//span[contains(text(), "View Details ")]');
+    this.saveButton = page.locator('//button[contains(text(), "Save")]');
     this.saveConfirmationPopup = page.locator('//button[contains(text(), "Confirm")]');
     this.openUserMenu = page.locator('//button[@aria-label = "Open user menu"]');
     this.clickOnSavedJobs = page.locator('//a[contains(text(), "Saved Jobs")]');

--- a/Hunt_Career_Playwright/pages/SearchPage.js
+++ b/Hunt_Career_Playwright/pages/SearchPage.js
@@ -28,22 +28,6 @@ export class SearchPage extends BasePage {
     this.noJobsFoundMessage = page.locator('p:has-text("No jobs found.")');
   }
 
-  getJobCardByIndex(index) {
-    const titleLocator = this.page
-      .locator(
-        "//h3[contains(@class, 'text-lg') and contains(@class, 'font-semibold')]",
-      )
-      .nth(index);
-
-    const cardLocator = titleLocator.locator("xpath=./ancestor::div[1]");
-    const saveButtonLocator = cardLocator.locator("button:has-text('Save')");
-
-    return {
-      getTitle: async () => await titleLocator.textContent(),
-      clickSave: async () => await saveButtonLocator.click(),
-    };
-  }
-
   // Dynamic locators
   searchTag(searchTerm) {
     return this.page.locator(`//span[contains(., "🔍 ${searchTerm}")]`);
@@ -63,6 +47,14 @@ export class SearchPage extends BasePage {
 
   jobTypeOption(jobType) {
     return this.page.locator(`//label[contains(., "${jobType}")]//input`);
+  }
+
+  jobCardTitle(index) {
+    return this.page
+      .locator(
+        "//h3[contains(@class, 'text-lg') and contains(@class, 'font-semibold')]",
+      )
+      .nth(index);
   }
 
   jobCardCompanyLocation(jobCard) {

--- a/Hunt_Career_Playwright/tests/search.spec.js
+++ b/Hunt_Career_Playwright/tests/search.spec.js
@@ -97,9 +97,9 @@ test.describe("Search Tests", () => {
   }) => {
     await loginAsValidUser(loginPage, loginData, page);
     await searchPage.search(searchData.validSearch.searchTerm);
-    const jobCard = searchPage.getJobCardByIndex(1);
-    const jobTitle = await jobCard.getTitle();
-    await jobCard.clickSave();
+    const jobIndex = 1;
+    const jobTitle = await searchPage.jobCardTitle(jobIndex).textContent();
+    await homePage.saveButton.nth(jobIndex).click();
     await homePage.saveConfirmationPopup.click();
     await expect(homePage.savedMessage(jobTitle)).toBeVisible();
     await homePage.openUserMenu.click();


### PR DESCRIPTION
This commit reverts the complex 'Job Card Object' refactoring in favor of a simpler, more direct approach to resolve persistent locator issues.

- The `getJobCardByIndex` method has been removed from `SearchPage.js`.
- The simpler `jobCardTitle(index)` method has been restored.
- The `saveButton` locator has been restored to `HomePage.js`.
- The `STC-6` test now uses parallel-indexed locators to find the job title and its corresponding save button.

This approach, while less elegant, is more resilient to the unknown HTML structure of the page and is confirmed to be a working solution.