### PR TITLE
Revert selectors to XPath and finalize Cypress framework refactoring.

### DIFF
--- a/Hunt_Career_Cypress/cypress/pageObjects/EmployerLoginPage.js
+++ b/Hunt_Career_Cypress/cypress/pageObjects/EmployerLoginPage.js
@@ -2,39 +2,39 @@ import { BasePage } from "./BasePage";
 
 export default class EmployerLoginPage extends BasePage {
     getEmailField() {
-        return cy.get("[data-cy=email-field]");
+        return cy.xpath("//input[@id='email']");
     }
 
     getPasswordField() {
-        return cy.get("[data-cy=password-field]");
+        return cy.xpath("//input[@id='password']");
     }
 
     getLoginButton() {
-        return cy.get("[data-cy=login-button]");
+        return cy.xpath("//button[@type='submit']");
     }
 
     getLoginSuccessMessage() {
-        return cy.contains("Logged in successfully!");
+        return cy.xpath("//div[contains(text(), 'Logged in successfully!')]");
     }
 
     getInvalidEmailOrPasswordMessage() {
-        return cy.contains("Invalid email or password");
+        return cy.xpath("//div[contains(text(), 'Invalid email or password')]");
     }
 
     getInvalidEmailAddressMessage() {
-        return cy.contains("Please enter a valid email address.");
+        return cy.xpath("//div[contains(text(), 'Please enter a valid email address.')]");
     }
 
     getPasswordLengthErrorMessage() {
-        return cy.contains("Password must be at least 8 characters long.");
+        return cy.xpath("//div[contains(text(), 'Password must be at least 8 characters long.')]");
     }
 
     getEmptyEmailMessage() {
-        return cy.contains("Email is required.");
+        return cy.xpath("//div[contains(text(), 'Email is required.')]");
     }
 
     getEmptyPasswordMessage() {
-        return cy.contains("Password is required.");
+        return cy.xpath("//div[contains(text(), 'Password is required.')]");
     }
 
     enterEmail(email) {

--- a/Hunt_Career_Cypress/cypress/pageObjects/EmployerRegisterPage.js
+++ b/Hunt_Career_Cypress/cypress/pageObjects/EmployerRegisterPage.js
@@ -2,43 +2,43 @@ import { BasePage } from "./BasePage";
 
 export default class EmployerRegisterPage extends BasePage {
     getNameField() {
-        return cy.get("[data-cy=employer-name-field]");
+        return cy.xpath("//input[@id='companyName']");
     }
     getEmailField() {
-        return cy.get("[data-cy=employer-email-field]");
+        return cy.xpath("//input[@id='email']");
     }
     getPasswordField() {
-        return cy.get("[data-cy=employer-password-field]");
+        return cy.xpath("//input[@id='password']");
     }
     getConfirmPasswordField() {
-        return cy.get("[data-cy=employer-confirm-password-field]");
+        return cy.xpath("//input[@id='confirmPassword']");
     }
     getSignupButton() {
-        return cy.get("[data-cy=employer-signup-button]");
+        return cy.xpath("//button[@type='submit']");
     }
     getSuccessCreationMessage() {
-        return cy.contains("Registered successfully! Please login.");
+        return cy.xpath("//div[contains(text(), 'Registered successfully! Please login.')]");
     }
     getDuplicateErrorMessage() {
-        return cy.contains("Employer already exists");
+        return cy.xpath("//div[contains(text(),'Employer already exists')]");
     }
     getNameBlankMessage() {
-        return cy.contains("Company Name is required.");
+        return cy.xpath("//div[contains(text(),'Company Name is required.')]");
     }
     getInvalidEmailAddressMessage() {
-        return cy.contains("Please enter a valid email address.");
+        return cy.xpath("//div[contains(text(), 'Please enter a valid email address.')]");
     }
     getEmailBlankMessage() {
-        return cy.contains("Email is required.");
+        return cy.xpath("//div[contains(text(), 'Email is required.')]");
     }
     getPasswordLengthErrorMessage() {
-        return cy.contains("Password must be at least 8 characters long.");
+        return cy.xpath("//div[contains(text(), 'Password must be at least 8 characters long.')]");
     }
     getPasswordMismatchMessage() {
-        return cy.contains("Passwords do not match.");
+        return cy.xpath("//div[contains(text(), 'Passwords do not match.')]");
     }
     getRegisterLinkHomePage() {
-        return cy.contains("Sign up");
+        return cy.xpath("//a[contains(text(), 'Sign up')]");
     }
 
     enterName(name) {

--- a/Hunt_Career_Cypress/cypress/pageObjects/LoginPage.js
+++ b/Hunt_Career_Cypress/cypress/pageObjects/LoginPage.js
@@ -2,47 +2,47 @@ import { BasePage } from "./BasePage";
 
 export default class LoginPage extends BasePage {
     getEmailField() {
-        return cy.get("[data-cy=email-field]");
+        return cy.xpath("//input[@id='email']");
     }
 
     getPasswordField() {
-        return cy.get("[data-cy=password-field]");
+        return cy.xpath("//input[@id='password']");
     }
 
     getLoginButton() {
-        return cy.get("[data-cy=login-button]");
+        return cy.xpath("//button[@aria-label='Login']");
     }
 
     getEmployerLoginButton() {
-        return cy.get("[data-cy=employer-login-button]");
+        return cy.xpath("//button[@type='submit']");
     }
 
     getLoginSuccessMessage() {
-        return cy.contains("Logged in successfully!");
+        return cy.xpath("//div[contains(text(), 'Logged in successfully!')]");
     }
 
     getInvalidEmailOrPasswordMessage() {
-        return cy.contains("Invalid email or password");
+        return cy.xpath("//div[contains(text(), 'Invalid email or password')]");
     }
 
     getInvalidEmailAddressMessage() {
-        return cy.contains("Please enter a valid email address.");
+        return cy.xpath("//div[contains(text(), 'Please enter a valid email address.')]");
     }
 
     getPasswordLengthErrorMessage() {
-        return cy.contains("Password must be at least 8 characters long.");
+        return cy.xpath("//div[contains(text(), 'Password must be at least 8 characters long.')]");
     }
 
     getEmptyEmailMessage() {
-        return cy.contains("Email is required.");
+        return cy.xpath("//div[contains(text(), 'Email is required.')]");
     }
 
     getEmptyPasswordMessage() {
-        return cy.contains("Password is required.");
+        return cy.xpath("//div[contains(text(), 'Password is required.')]");
     }
 
     getLoginHomeLink() {
-        return cy.contains("Login");
+        return cy.xpath("//a[contains(text(), 'Login')]");
     }
 
     enterEmail(email) {

--- a/Hunt_Career_Cypress/cypress/pageObjects/RegisterPage.js
+++ b/Hunt_Career_Cypress/cypress/pageObjects/RegisterPage.js
@@ -2,88 +2,88 @@ import { BasePage } from "./BasePage";
 
 export default class RegisterPage extends BasePage {
     getFirstNameField() {
-        return cy.get("[data-cy=first-name-field]");
+        return cy.xpath("//input[@id='firstName']");
     }
     getLastNameField() {
-        return cy.get("[data-cy=last-name-field]");
+        return cy.xpath("//input[@id='lastName']");
     }
     getEmailField() {
-        return cy.get("[data-cy=email-field]");
+        return cy.xpath("//input[@id='email']");
     }
     getPasswordField() {
-        return cy.get("[data-cy=password-field]");
+        return cy.xpath("//input[@id='password']");
     }
     getConfirmPasswordField() {
-        return cy.get("[data-cy=confirm-password-field]");
+        return cy.xpath("//input[@id='confirmPassword']");
     }
     getPhoneNumberField() {
-        return cy.get("[data-cy=phone-number-field]");
+        return cy.xpath("//input[@id='phoneNumber']");
     }
     getFirstNextButton() {
-        return cy.get("[data-cy=first-next-button]");
+        return cy.xpath("//button[@type='button']");
     }
     getSecondNextButton() {
-        return cy.get("[data-cy=second-next-button]");
+        return cy.xpath("//button[normalize-space()='Next']");
     }
     getSignupButton() {
-        return cy.get("[data-cy=signup-button]");
+        return cy.xpath("//button[@aria-label='Sign up']");
     }
     getSuccessCreationMessage() {
-        return cy.contains("Registered successfully! Please login.");
+        return cy.xpath("//div[contains(text(), 'Registered successfully! Please login.')]");
     }
     getDuplicateErrorMessage() {
-        return cy.contains("User already exists");
+        return cy.xpath("//div[contains(text(),'User already exists')]");
     }
     getDuplicateErrorMessageForEmployer() {
-        return cy.contains("Employer already exists");
+        return cy.xpath("//div[contains(text(),'Employer already exists')]");
     }
     getFirstNameBlankMessage() {
-        return cy.contains("First Name is required.");
+        return cy.xpath("//div[contains(text(),'First Name is required.')]");
     }
     getEmployerNameBlankMessage() {
-        return cy.contains("Company Name is required.");
+        return cy.xpath("//div[contains(text(),'Company Name is required.')]");
     }
     getLastNameBlankMessage() {
-        return cy.contains("Last Name is required.");
+        return cy.xpath("//div[contains(text(),'Last Name is required.')]");
     }
     getInvalidEmailAddressMessage() {
-        return cy.contains("Please enter a valid email address.");
+        return cy.xpath("//div[contains(text(), 'Please enter a valid email address.')]");
     }
     getEmailBlankMessage() {
-        return cy.contains("Email is required.");
+        return cy.xpath("//div[contains(text(), 'Email is required.')]");
     }
     getPasswordLengthErrorMessage() {
-        return cy.contains("Password must be at least 8 characters long.");
+        return cy.xpath("//div[contains(text(), 'Password must be at least 8 characters long.')]");
     }
     getPasswordMismatchMessage() {
-        return cy.contains("Passwords do not match.");
+        return cy.xpath("//div[contains(text(), 'Passwords do not match.')]");
     }
     getPhoneNumberRequiredMessage() {
-        return cy.contains("Phone Number is required.");
+        return cy.xpath("//div[contains(text(), 'Phone Number is required.')]");
     }
     getInvalidPhoneNumberMessage() {
-        return cy.contains("Please enter a valid 10-digit phone number.");
+        return cy.xpath("//div[contains(text(), 'Please enter a valid 10-digit phone number.')]");
     }
     getRegisterLinkHomePage() {
-        return cy.contains("Signup");
+        return cy.xpath("//a[contains(text(), 'Signup')]");
     }
     getEmployerSignupLink() {
-        return cy.contains("Sign up");
+        return cy.xpath("//a[contains(text(), 'Sign up')]");
     }
     getEmployerRegisterNameField() {
-        return cy.get("[data-cy=employer-name-field]");
+        return cy.xpath("//input[@id='companyName']");
     }
     getEmployerRegisterEmailField() {
-        return cy.get("[data-cy=employer-email-field]");
+        return cy.xpath("//input[@id='email']");
     }
     getEmployerRegisterPasswordField() {
-        return cy.get("[data-cy=employer-password-field]");
+        return cy.xpath("//input[@id='password']");
     }
     getEmployerRegisterConfirmPasswordField() {
-        return cy.get("[data-cy=employer-confirm-password-field]");
+        return cy.xpath("//input[@id='confirmPassword']");
     }
     getEmployerRegisterSignupButton() {
-        return cy.get("[data-cy=employer-signup-button]");
+        return cy.xpath("//button[@type='submit']");
     }
 
     enterFirstName(firstName) {

--- a/Hunt_Career_Cypress/cypress/pageObjects/SearchPage.js
+++ b/Hunt_Career_Cypress/cypress/pageObjects/SearchPage.js
@@ -2,67 +2,67 @@ import { BasePage } from "./BasePage";
 
 export default class SearchPage extends BasePage {
     getSearchInputField() {
-        return cy.get("[data-cy=search-input]");
+        return cy.xpath("//input[@placeholder='Search jobs by title, company, or keyword...']");
     }
 
     getSearchButton() {
-        return cy.get("[data-cy=search-button]");
+        return cy.xpath("//button[@aria-label='Search']");
     }
 
     getLocationFilterButton() {
-        return cy.get("[data-cy=location-filter-button]");
+        return cy.xpath("//button[@aria-label='Toggle location filter dropdown']");
     }
 
     getLocationSearchInput() {
-        return cy.get("[data-cy=location-search-input]");
+        return cy.xpath("//input[@placeholder='Search location...']");
     }
 
     getLocationOption(location) {
-        return cy.get("[data-cy=location-option]").contains(location);
+        return cy.get('label').contains(location).find('input');
     }
 
     getJobTypeFilterButton() {
-        return cy.get("[data-cy=job-type-filter-button]");
+        return cy.xpath("//button[@aria-label='Toggle job type filter dropdown']");
     }
 
     getJobTypeSearchInput() {
-        return cy.get("[data-cy=job-type-search-input]");
+        return cy.xpath("//input[@placeholder='Search job type...']");
     }
 
     getJobTypeOption(jobType) {
-        return cy.get("[data-cy=job-type-option]").contains(jobType);
+        return cy.get('label').contains(jobType).find('input');
     }
 
     getClearAllFiltersButton() {
-        return cy.get("[data-cy=clear-filters-button]");
+        return cy.xpath("//button[@aria-label='Clear all filters']");
     }
 
     getJobCardTitle(jobCard) {
-        return jobCard.find("[data-cy=job-card-title]");
+        return jobCard.find('h3.text-lg.font-semibold');
     }
 
     getJobCardCompanyLocation(jobCard) {
-        return jobCard.find("[data-cy=job-card-company-location]");
+        return jobCard.find('p.text-gray-600');
     }
 
     getJobCardDescription(jobCard) {
-        return jobCard.find("[data-cy=job-card-description]");
+        return jobCard.find('p.text-sm.text-gray-700.mt-3.line-clamp-3');
     }
 
     getNoJobsFoundMessage() {
-        return cy.contains("No jobs found.");
+        return cy.get('p').contains('No jobs found.');
     }
 
     getSearchTag(searchTerm) {
-        return cy.contains(`🔍 ${searchTerm}`);
+        return cy.xpath(`//span[contains(., "🔍 ${searchTerm}")]`);
     }
 
     getLocationTag(location) {
-        return cy.contains(`📍 ${location}`);
+        return cy.xpath(`//span[contains(., "📍 ${location}")]`);
     }
 
     getJobTypeTag(jobType) {
-        return cy.contains(`🧾 ${jobType}`);
+        return cy.xpath(`//span[contains(., "🧾 ${jobType}")]`);
     }
 
     enterSearchTerm(searchTerm) {


### PR DESCRIPTION
- Reverted all element selectors from `data-cy` attributes back to the original XPath expressions as requested.
- Preserved all other refactoring improvements, including modular Page Object Models, consistent naming conventions, and clearer test descriptions.