### PR TITLE
Fix: Remove Email Notifications and Improve Exception Handling in CI

### DIFF
--- a/Hunt_Career_Cypress/Jenkinsfile
+++ b/Hunt_Career_Cypress/Jenkinsfile
@@ -69,36 +69,30 @@ pipeline {
         always {
             // This block will always run, regardless of the pipeline's status
             dir('Hunt_Career_Cypress') {
-                printBanner('ARCHIVING & PUBLISHING REPORTS')
+                script {
+                    try {
+                        printBanner('ARCHIVING & PUBLISHING REPORTS')
 
-                // Archive test reports and artifacts
-                archiveArtifacts artifacts: 'mochawesome-report/**', allowEmptyArchive: true
-                archiveArtifacts artifacts: 'cypress/screenshots/**/*.png', allowEmptyArchive: true
-                archiveArtifacts artifacts: 'cypress/videos/**/*.mp4', allowEmptyArchive: true
+                        // Archive test reports and artifacts
+                        archiveArtifacts artifacts: 'mochawesome-report/**', allowEmptyArchive: true
+                        archiveArtifacts artifacts: 'cypress/screenshots/**/*.png', allowEmptyArchive: true
+                        archiveArtifacts artifacts: 'cypress/videos/**/*.mp4', allowEmptyArchive: true
 
-                // Publish HTML reports
-                publishHTML(target: [
-                    allowMissing: true,
-                    alwaysLinkToLastBuild: true,
-                    keepAll: true,
-                    reportDir: 'mochawesome-report',
-                    reportFiles: 'mochawesome.html',
-                    reportName: 'Cypress Test Report'
-                ])
-            }
-        }
-
-        failure {
-            // Send email notification on failure, wrapped in a try-catch block
-            script {
-                try {
-                    mail to: 'qa-team@example.com',
-                         subject: "❌ Cypress Pipeline Failed: ${env.JOB_NAME} #${env.BUILD_NUMBER}",
-                         body: "The Cypress test pipeline failed. Please check Jenkins for details: ${env.BUILD_URL}"
-                } catch (err) {
-                    echo "⚠️ Failed to send email notification: ${err.message}"
+                        // Publish HTML reports
+                        publishHTML(target: [
+                            allowMissing: true,
+                            alwaysLinkToLastBuild: true,
+                            keepAll: true,
+                            reportDir: 'mochawesome-report',
+                            reportFiles: 'mochawesome.html',
+                            reportName: 'Cypress Test Report'
+                        ])
+                    } catch (err) {
+                        echo "⚠️  Could not publish reports: ${err.message}"
+                    }
                 }
             }
+        }
     }
 }
 }

--- a/Hunt_Career_Playwright/Jenkinsfile
+++ b/Hunt_Career_Playwright/Jenkinsfile
@@ -69,28 +69,27 @@ pipeline {
         always {
             // This block will always run, regardless of the pipeline's status
             dir('Hunt_Career_Playwright') {
-                printBanner('ARCHIVING & PUBLISHING REPORTS')
+                script {
+                    try {
+                        printBanner('ARCHIVING & PUBLISHING REPORTS')
 
-                // Archive test reports and artifacts
-                archiveArtifacts artifacts: 'playwright-report/**/*', allowEmptyArchive: true
+                        // Archive test reports and artifacts
+                        archiveArtifacts artifacts: 'playwright-report/**/*', allowEmptyArchive: true
 
-                // Publish HTML reports
-                publishHTML(target: [
-                    allowMissing: true,
-                    alwaysLinkToLastBuild: true,
-                    keepAll: true,
-                    reportDir: 'playwright-report',
-                    reportFiles: 'index.html',
-                    reportName: 'Playwright Test Report'
-                ])
+                        // Publish HTML reports
+                        publishHTML(target: [
+                            allowMissing: true,
+                            alwaysLinkToLastBuild: true,
+                            keepAll: true,
+                            reportDir: 'playwright-report',
+                            reportFiles: 'index.html',
+                            reportName: 'Playwright Test Report'
+                        ])
+                    } catch (err) {
+                        echo "⚠️  Could not publish reports: ${err.message}"
+                    }
+                }
             }
-        }
-
-        failure {
-            // Send email notification on failure
-            mail to: 'qa-team@example.com',
-                 subject: "❌ Playwright Pipeline Failed: ${env.JOB_NAME} #${env.BUILD_NUMBER}",
-                 body: "The Playwright test pipeline failed. Please check Jenkins for details: ${env.BUILD_URL}"
         }
     }
 }

--- a/Hunt_Career_TestNG_Hybrid_Framework/Jenkinsfile
+++ b/Hunt_Career_TestNG_Hybrid_Framework/Jenkinsfile
@@ -65,28 +65,27 @@ pipeline {
         always {
             // This block will always run, regardless of the pipeline's status
             dir('Hunt_Career_TestNG_Hybrid_Framework') {
-                printBanner('ARCHIVING & PUBLISHING REPORTS')
+                script {
+                    try {
+                        printBanner('ARCHIVING & PUBLISHING REPORTS')
 
-                // Archive and publish JUnit test results
-                junit testResults: 'target/surefire-reports/testng-results.xml', allowEmptyResults: true
+                        // Archive and publish JUnit test results
+                        junit testResults: 'target/surefire-reports/testng-results.xml', allowEmptyResults: true
 
-                // Publish HTML reports
-                publishHTML(target: [
-                    allowMissing: true,
-                    alwaysLinkToLastBuild: true,
-                    keepAll: true,
-                    reportDir: 'test-output/ExtentReports',
-                    reportFiles: 'extentReport.html',
-                    reportName: 'Extent Test Report'
-                ])
+                        // Publish HTML reports
+                        publishHTML(target: [
+                            allowMissing: true,
+                            alwaysLinkToLastBuild: true,
+                            keepAll: true,
+                            reportDir: 'test-output/ExtentReports',
+                            reportFiles: 'extentReport.html',
+                            reportName: 'Extent Test Report'
+                        ])
+                    } catch (err) {
+                        echo "⚠️  Could not publish reports: ${err.message}"
+                    }
+                }
             }
-        }
-
-        failure {
-            // Send email notification on failure
-            mail to: 'qa-team@example.com',
-                 subject: "❌ TestNG Pipeline Failed: ${env.JOB_NAME} #${env.BUILD_NUMBER}",
-                 body: "The TestNG test pipeline failed. Please check Jenkins for details: ${env.BUILD_URL}"
         }
     }
 }


### PR DESCRIPTION
This commit addresses failures in the CI pipelines by making two key improvements:

1.  **Removed Email Notifications:** The `failure` block, which was responsible for sending email notifications, has been removed from the `Jenkinsfile` for the TestNG, Cypress, and Playwright pipelines. This addresses the user's request to disable mailing on failure.

2.  **Improved Exception Handling:** The report publishing and artifact archiving steps in the `always` block of each pipeline have been wrapped in a `try-catch` block. This ensures that any errors during the reporting phase do not cause the entire pipeline to fail, making the CI process more robust.

These changes have been applied consistently across all three downstream pipelines to ensure a stable and reliable CI environment.